### PR TITLE
fix: Make work on Node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ node_js:
   - iojs-v1
   - '0.12'
   - '0.11.15'
+  - '0.10'
 before_install:
   - npm i -g npm@^2.0.0
 before_script:


### PR DESCRIPTION
Seems that asking for "constructor" is a thing with 0.10. Pass that
through.

Nanify some syntax, trim skipped property accesses.  Check for
pre-symbol symbols.

Place 0.10 in the Travis version list.

This fixes #3