### PR TITLE
Only the lead builder releases + update packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,19 @@ before_install:
   - npm i -g npm@^2.0.0
 before_script:
   - npm prune
+after_script:
+  - echo leader=$BUILD_LEADER status=$BUILD_AGGREGATE_STATUS
 after_success:
   - 'curl -Lo travis_after_all.py https://git.io/travis_after_all'
   - python travis_after_all.py
   - 'export $(cat .to_export_back) &> /dev/null'
-  - npm run semantic-release
+  - |
+      if [ "$BUILD_LEADER" = "YES" -a "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
+        echo "Checking coverage and release status."
+        npm run semantic-release
+      else
+        echo "Either I'm a minion or the build failed. No semantic-releasing for me."
+      fi
 branches:
   except:
     - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bindings": "^1.2.1",
     "chai": "^3.5.0",
     "cz-conventional-changelog": "^1.1.5",
-    "mocha": "^2.4.5",
+    "mocha": "^3.1.2",
     "node-gyp": "^3.2.1",
     "semantic-release": "^4.3.5"
   },


### PR DESCRIPTION
This make it so only the lead builder on Travis will do the semantic-release run.

Update Mocha to newest.