### PR TITLE
Set up for binary releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,19 +18,6 @@ before_install:
   - npm i -g npm@^2.0.0
 before_script:
   - npm prune
-after_script:
-  - echo leader=$BUILD_LEADER status=$BUILD_AGGREGATE_STATUS
-after_success:
-  - 'curl -Lo travis_after_all.py https://git.io/travis_after_all'
-  - python travis_after_all.py
-  - 'export $(cat .to_export_back) &> /dev/null'
-  - |
-      if [ "$BUILD_LEADER" = "YES" -a "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
-        echo "Checking coverage and release status."
-        npm run semantic-release
-      else
-        echo "Either I'm a minion or the build failed. No semantic-releasing for me."
-      fi
 branches:
   except:
     - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/README.md
+++ b/README.md
@@ -54,3 +54,17 @@ Symbols are not supported as properties.
 You cannot use undefined checks with this structure as the very act of
 checking ensures that the structure is defined. Use membership or
 length checks to determine if something is empty.
+
+## Publishing a binary release
+
+To make a new binary release:
+
+- Edit package.json. Increment the `version` property.
+- `node-pre-gyp rebuild`
+- `node-pre-gyp package`
+- `node-pre-gyp-github publish`
+- `npm publish`
+
+You will need a `NODE_PRE_GYP_GITHUB_TOKEN` with `repo:status`,
+`repo_deployment` and `public_repo` access to the target repo. You'll
+also need write access to the npm repo.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "main": "build/Release/autovivify",
   "scripts": {
     "test": "mocha",
-    "install": "node-gyp rebuild",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "install": "node-gyp rebuild"
+  },
+  "binary": {
+    "module_name": "autovivify",
+    "module_path": "build/Release",
+    "host": "https://github.com/allenluce/node-autovivify/releases/download/{version}"
   },
   "author": "Allen Luce",
   "repository": {
@@ -14,24 +18,27 @@
   },
   "license": "ISC",
   "gypfile": true,
-  "dependencies": {
-    "nan": "^2.2.0"
-  },
   "devDependencies": {
     "bindings": "^1.2.1",
     "chai": "^3.5.0",
     "cz-conventional-changelog": "^1.1.5",
     "mocha": "^3.1.2",
-    "node-gyp": "^3.2.1",
-    "semantic-release": "^4.3.5"
+    "nan": "^2.2.0",
+    "node-gyp": "^3.2.1"
   },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
+  "version": "1.0.8",
   "engines": {
-    "node": ">= 0.11.15",
+    "node": ">= 0.10",
     "iojs": ">= 1.0.0"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.6.9",
+    "node-pre-gyp": "^0.6.30",
+    "node-pre-gyp-github": "^1.3.1"
   }
 }


### PR DESCRIPTION
Use node-pre-gyp-github.  Ditch semantic-versioning, as it doesn't
currently play well with node-pre-gyp.