### PR TITLE
Fixing binary releases.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,12 +1,27 @@
 {
   "targets": [
     {
-      "target_name": "autovivify",
+      "target_name": "<(module_name)",
       "sources": [
         "autovivify.cc"
       ],
       "include_dirs": [
         "<!(node -e \"require('nan')\")"
+      ]
+    },
+    {
+      "target_name": "action_after_build",
+      "type": "none",
+      "dependencies": [
+        "<(module_name)"
+      ],
+      "copies": [
+        {
+          "files": [
+            "<(PRODUCT_DIR)/<(module_name).node"
+          ],
+          "destination": "<(module_path)"
+        }
       ]
     }
   ]

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+var binary = require('node-pre-gyp')
+var path = require('path')
+var binding_path = binary.find(path.resolve(path.join(__dirname,'./package.json')))
+module.exports = require(binding_path)

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "autovivify",
   "description": "Automatic creation of subobjects and arrays",
-  "main": "build/Release/autovivify",
+  "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "install": "node-gyp rebuild"
+    "install": "node-pre-gyp install --fallback-to-build"
   },
   "binary": {
     "module_name": "autovivify",
-    "module_path": "build/Release",
+    "module_path": "./build/{configuration}/{node_abi}-{platform}-{arch}/",
+    "package_name": "autovivify-{node_abi}-{platform}-{arch}.tar.gz",
     "host": "https://github.com/allenluce/node-autovivify/releases/download/{version}"
   },
   "author": "Allen Luce",
@@ -22,22 +23,22 @@
     "bindings": "^1.2.1",
     "chai": "^3.5.0",
     "cz-conventional-changelog": "^1.1.5",
-    "mocha": "^3.1.2",
-    "nan": "^2.2.0",
-    "node-gyp": "^3.2.1"
+    "mocha": "^3.1.2"
   },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
-  "version": "1.0.8",
+  "version": "1.0.11",
   "engines": {
     "node": ">= 0.10",
     "iojs": ">= 1.0.0"
   },
   "dependencies": {
     "aws-sdk": "^2.6.9",
+    "nan": "^2.2.0",
+    "node-gyp": "^3.2.1",
     "node-pre-gyp": "^0.6.30",
     "node-pre-gyp-github": "^1.3.1"
   }

--- a/test/test-autovivify.js
+++ b/test/test-autovivify.js
@@ -1,6 +1,6 @@
 /* global describe it beforeEach */
 const expect = require('chai').expect
-const Av = require('bindings')('autovivify')
+const Av = require('..')
 const eql = require('./equal')
 
 describe('Autovivify', function () {


### PR DESCRIPTION
Point to an agreeable path, pull in things required for binary building
fallback. Add the necessary stuff to bindings.gyp for node-pre-gyp. Make
an index.js that can find the binary module.